### PR TITLE
Remove width property on body style

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -40,7 +40,6 @@ body {
   grid-template-columns: auto 60%;
   grid-template-areas:". body";
 
-  width: 1900px;
 
   & > div {
   grid-area: body;


### PR DESCRIPTION
A global set pixel width on body causes the grid layout to render at fixed width, which cuts off the page content on smaller browser widths.